### PR TITLE
Added SEO language meta info and canonical links to template

### DIFF
--- a/conceptual.html.primary.js
+++ b/conceptual.html.primary.js
@@ -19,13 +19,16 @@ exports.transform = function (model) {
   model._isLangEn = true;
   model._isLangJa = false;
   model._isLangKr = false;
+  model._appLang = "en";
   if (model._language) {
     if (model._language === "ja") {
       model._isLangJa = true;
       model._isLangEn = model._isLangKr = false;
+      model._appLang = "ja";
     } else if (model._language === "kr") {
       model._isLangKr = true;
       model._isLangEn = model._isLangJa = false;
+      model._appLang = "ko";
     }
   }
 

--- a/layout/_master.tmpl
+++ b/layout/_master.tmpl
@@ -3,7 +3,7 @@ full license information.}} {{!include(/^styles/.*/)}} {{!include(/^fonts/.*/)}}
 {{!include(search-stopwords.json)}}
 <!DOCTYPE html>
 <!--[if IE]><![endif]-->
-<html>
+<html lang="{{_appLang}}">
 {{>partials/head}}
 
 <body data-spy="scroll" data-target="#affix" data-nav-base-url="{environment:infragisticsBaseUrl}" data-lang="{{_language}}" data-theme="{{_productThemeName}}">

--- a/partials/head.tmpl.partial
+++ b/partials/head.tmpl.partial
@@ -14,7 +14,15 @@ full license information.}}
     <meta property="docfx:tocrel" content="{{_tocRel}}"> {{#_noindex}}
     <meta name="searchOption" content="noindex">{{/_noindex}} {{#_enableSearch}}
     <meta property="docfx:rel" content="{{_rel}}">{{/_enableSearch}} {{#_enableNewTab}}
-    <meta property="docfx:newtab" content="true">{{/_enableNewTab}} {{#_extraFont}}
+    <meta property="docfx:newtab" content="true">{{/_enableNewTab}} 
+    <link rel="canonical" href="{{_currentBaseUrl}}{{_path}}" />
+    <link rel="alternate" href="{{_ENBaseUrl}}{{_path}}" hreflang="en" />
+    <link rel="alternate" href="{{_ENBaseUrl}}{{_path}}" hreflang="en-us" />
+    <link rel="alternate" href="{{_JABaseUrl}}{{_path}}" hreflang="ja" />
+    <link rel="alternate" href="{{_JABaseUrl}}{{_path}}" hreflang="ja-jp" />{{#_hasKRLang}}
+    <link rel="alternate" href="{{_KRBaseUrl}}{{_path}}" hreflang="ko" />
+    <link rel="alternate" href="{{_KRBaseUrl}}{{_path}}" hreflang="ko-kr" /> {{/_hasKRLang}}
+    <link rel="alternate" href="{{_ENBaseUrl}}{{_path}}" hreflang="x-default" />{{#_extraFont}}
     <link rel="stylesheet" href="{{_extraFont}}"> {{/_extraFont}}
     <link rel="shortcut icon" href="https://www.infragistics.com/assets/images/favicon.ico">
     <link rel="stylesheet" href="https://infragistics.com/assets/modern/css/layout.css">


### PR DESCRIPTION
Hi @tiliev 

I've added some SEO changes to the template that I wanted you to review. I've added the following:

1. Lang attribute on the <html> element
2. Added Canonical link
3. Added HrefLang links

Items number 2 and 3 assume some variables have been added to the global.json file for the environments under igniteui-docfx and indigo-design-docfx. I'll be adding PR for changes to each of those repos shortly.