### PR TITLE
Introduced JP typescript documentation links

### DIFF
--- a/post-processors/PostProcessors/EnvironmentVariables/preconfig.json
+++ b/post-processors/PostProcessors/EnvironmentVariables/preconfig.json
@@ -31,21 +31,21 @@
 			"development": {
 				"demosBaseUrl": "http://localhost:4200",
 				"infragisticsBaseUrl": "https://jp.staging.infragistics.local",
-				"angularApiUrl": "https://staging.infragistics.local/products/ignite-ui-angular/docs/typescript",
+				"angularApiUrl": "https://jp.staging.infragistics.local/products/ignite-ui-angular/docs/typescript",
 				"sassApiUrl": "https://staging.infragistics.local/products/ignite-ui-angular/docs/sass",
 				"GTMContainerId": "GTM-NNHVMC7"
 			},
 			"staging": {
 				"demosBaseUrl": "https://jp.staging.infragistics.local/angular-demos",
 				"infragisticsBaseUrl": "https://jp.staging.infragistics.local",
-				"angularApiUrl": "https://staging.infragistics.local/products/ignite-ui-angular/docs/typescript",
+				"angularApiUrl": "https://jp.staging.infragistics.local/products/ignite-ui-angular/docs/typescript",
 				"sassApiUrl": "https://staging.infragistics.local/products/ignite-ui-angular/docs/sass",
 				"GTMContainerId": "GTM-WLWSDK"
 			},
 			"production": {
 				"demosBaseUrl": "https://jp.infragistics.com/angular-demos",
 				"infragisticsBaseUrl": "https://jp.infragistics.com",
-				"angularApiUrl": "https://www.infragistics.com/products/ignite-ui-angular/docs/typescript",
+				"angularApiUrl": "https://jp.infragistics.com/products/ignite-ui-angular/docs/typescript",
 				"sassApiUrl": "https://www.infragistics.com/products/ignite-ui-angular/docs/sass",
 				"GTMContainerId": "GTM-KVNSWJ"
 			}


### PR DESCRIPTION
Introducing JP TypeScript documentation environment variables.
Staging: https://jp.staging.infragistics.local/products/ignite-ui-angular/docs/typescript/
Production: https://jp.infragistics.com/products/ignite-ui-angular/docs/typescript/