### PR TITLE
fix(breadcrumb): remove overlapping content - vnext

### DIFF
--- a/src/styles/shared/_layout.scss
+++ b/src/styles/shared/_layout.scss
@@ -243,6 +243,15 @@ svg:hover path {
 	display: none;
 }
 
+
+@media (min-width: 770px) and (max-width: 1475px) {
+	.wrap-content-m {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+	} 
+}
+
 @media (min-width: 992px) {
 	#main {
 		display: table;

--- a/template/partials/navbar.tmpl.partial
+++ b/template/partials/navbar.tmpl.partial
@@ -23,7 +23,7 @@ full license information.}}
     {{#_isLangKr}}
         {{>partials/infranav.kr}}
     {{/_isLangKr}}
-    <div class="container-fluid">
+    <div class="container-fluid wrap-content-m">
 
         <div class="navbar-header navbar-wrapper">
              {{>partials/logo}}


### PR DESCRIPTION
Close #394 

| Before | After | 
|---|---|
| ![image](https://user-images.githubusercontent.com/33124382/198527577-e2682d6f-bc55-4a08-a037-a5b6fe11e3e3.png) | ![image](https://user-images.githubusercontent.com/33124382/198527653-4c8f62bf-3be2-495e-9fae-ede652c8b056.png) |

