### PR TITLE
fix(breadcrumb): remove overlapping content - master

### DIFF
--- a/src/styles/shared/_layout.scss
+++ b/src/styles/shared/_layout.scss
@@ -243,6 +243,14 @@ svg:hover path {
 	display: none;
 }
 
+@media (min-width: 770px) and (max-width: 1475px) {
+	.wrap-content-m {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+	} 
+}
+
 @media (min-width: 992px) {
 	#main {
 		display: table;

--- a/template/partials/navbar.tmpl.partial
+++ b/template/partials/navbar.tmpl.partial
@@ -23,7 +23,7 @@ full license information.}}
     {{#_isLangKr}}
         {{>partials/infranav.kr}}
     {{/_isLangKr}}
-    <div class="container-fluid">
+    <div class="container-fluid wrap-content-m">
 
         <div class="navbar-header navbar-wrapper">
              {{>partials/logo}}


### PR DESCRIPTION
Close #394 

| Before | After | 
|---|---|
| ![image](https://user-images.githubusercontent.com/33124382/198535549-e3355659-4d1a-4079-aa01-cbd98649f294.png) | ![image](https://user-images.githubusercontent.com/33124382/198535584-1e40a81f-4764-4191-884f-63ebf79e021a.png) |

