### PR TITLE
chore(angular): Remove angular trailing slash for codeview when using SSR

### DIFF
--- a/src/app/services/code-view/angular-code-service.ts
+++ b/src/app/services/code-view/angular-code-service.ts
@@ -273,7 +273,8 @@ export class AngularCodeService extends CodeService {
 
     private getAngularSampleMetadataUrl(demosBaseUrl: string, sampleUrl: string) {
         let demoFileMetadataName = sampleUrl.replace(demosBaseUrl + "/", "")
-            .replace(/\?[\w\W]+/, '');
+            .replace(/\?[\w\W]+/, '').replace(/\/$/, '');
+            // Replace the trailing slash coming from angular SSR in case there is so that the request for codesandbox and stackblitz works
 
         let demoFileMetadataPath = '';
         if (this.isDvSample(demosBaseUrl, sampleUrl)) {


### PR DESCRIPTION
With the newly introduced trailing slash to the angular samples because of SSR, the codeview, stackblitz and codesandbox dont work. 
The fix is to remove the last trailing slash from the angular sample url if exists so that the docfx can request the correct resource needed for initializing the code view.