### PR TITLE
fix(FireFox): Fix scroll on click of anchor for section.

### DIFF
--- a/src/app/services/rendering/affix.ts
+++ b/src/app/services/rendering/affix.ts
@@ -37,9 +37,10 @@ export class AffixRenderingService extends RenderingService implements Resizable
       this.resizingService.observeElement(this);
       $<HTMLAnchorElement>(".bs-docs-sidenav a").on("click", (evt) => {
         evt.preventDefault();
-        util.scroll($(evt?.target)?.attr("href")!);
-        if($(evt?.target)?.attr("href")! !== location.hash) 
-          history.pushState({scrollPosition: $(window).scrollTop()}, "", $(evt?.target)?.attr("href")!);
+        const hash = $(evt?.target)?.prop('hash')!;
+        util.scroll(hash);
+        if(hash !== location.hash) 
+          history.pushState({scrollPosition: $(window).scrollTop()}, "", hash);
       });
     } else {
       $("#affix").empty();


### PR DESCRIPTION
Closes https://github.com/IgniteUI/igniteui-blazor-examples/issues/1107

Issue was specific to FireFox, because in it `.attr("href")` returns the resolved (absolute) URL, which is not a valid selector for the `find` method used to find the target section to scroll to. That was throwing errors, like:

Uncaught Error: Syntax error, unrecognized expression: https://staging.infragistics.com/products/ignite-ui-blazor/blazor/components/grids/tree-grid/filtering#setup

Changing it to use the hash prop, which returns just the hash (like `#setup`) consistently between browsers.